### PR TITLE
WIP for internal review: Fix creation of metadata with no SLS

### DIFF
--- a/demo-django/saml/settings.json
+++ b/demo-django/saml/settings.json
@@ -11,7 +11,7 @@
             "url": "https://<sp_domain>/?sls",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
-        "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDFormats": ["urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"],
         "x509cert": "",
         "privateKey": ""
     },
@@ -25,6 +25,8 @@
             "url": "https://app.onelogin.com/trust/saml2/http-redirect/slo/<onelogin_connector_id>",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
+        "NameIDPolicyFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDPolicyAllowCreate": true,
         "x509cert": "<onelogin_connector_cert>"
     }
 }

--- a/demo-flask/saml/settings.json
+++ b/demo-flask/saml/settings.json
@@ -11,7 +11,7 @@
             "url": "https://<sp_domain>/?sls",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
-        "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDFormats": ["urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"],
         "x509cert": "",
         "privateKey": ""
     },
@@ -25,6 +25,8 @@
             "url": "https://app.onelogin.com/trust/saml2/http-redirect/slo/<onelogin_connector_id>",
             "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
         },
+        "NameIDPolicyFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDPolicyAllowCreate": true,
         "x509cert": "<onelogin_connector_cert>"
     }
 }

--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -64,7 +64,7 @@ class OneLogin_Saml2_Logout_Request(object):
                 cert = idp_data['x509cert']
 
             if name_id is not None:
-                nameIdFormat = sp_data['NameIDFormat']
+                nameIdFormat = idp_data['NameIDPolicyFormat']
             else:
                 name_id = idp_data['entityId']
                 nameIdFormat = OneLogin_Saml2_Constants.NAMEID_ENTITY

--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -74,7 +74,7 @@ class OneLogin_Saml2_Metadata(object):
             organization = {}
 
         sls = ''
-        if 'singleLogoutService' in sp:
+        if 'singleLogoutService' in sp and 'url' in sp['singleLogoutService']:
             sls = """        <md:SingleLogoutService Binding="%(binding)s"
                                 Location="%(location)s" />\n""" % \
                 {

--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -41,11 +41,11 @@ class OneLogin_Saml2_Metadata(object):
         :param wsign: wantAssertionsSigned attribute
         :type wsign: string
 
-        :param valid_until: Metadata's valid time
-        :type valid_until: string|DateTime
+        :param valid_until: Metadata's expiry date
+        :type valid_until: string|DateTime|Timestamp
 
         :param cache_duration: Duration of the cache in seconds
-        :type cache_duration: string|Timestamp
+        :type cache_duration: int|string
 
         :param contacts: Contacts info
         :type contacts: dict
@@ -56,15 +56,18 @@ class OneLogin_Saml2_Metadata(object):
         if valid_until is None:
             valid_until = int(datetime.now().strftime("%s")) + OneLogin_Saml2_Metadata.TIME_VALID
         if not isinstance(valid_until, basestring):
-            valid_until_time = gmtime(valid_until)
-            valid_until_time = strftime(r'%Y-%m-%dT%H:%M:%SZ', valid_until_time)
+            if isinstance(valid_until, datetime):
+                valid_until_time = valid_until
+            else:
+                valid_until_time = gmtime(valid_until)
+            valid_until_str = strftime(r'%Y-%m-%dT%H:%M:%SZ', valid_until_time)
         else:
-            valid_until_time = valid_until
+            valid_until_str = valid_until
 
         if cache_duration is None:
-            cache_duration = int(datetime.now().strftime("%s")) + OneLogin_Saml2_Metadata.TIME_CACHED
+            cache_duration = OneLogin_Saml2_Metadata.TIME_CACHED
         if not isinstance(cache_duration, basestring):
-            cache_duration_str = 'PT%sS' % cache_duration
+            cache_duration_str = 'PT%sS' % cache_duration  # 'P'eriod of 'T'ime x 'S'econds
         else:
             cache_duration_str = cache_duration
 
@@ -125,8 +128,8 @@ class OneLogin_Saml2_Metadata(object):
 
         metadata = """<?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
-                     validUntil="%(valid)s"
-                     cacheDuration="%(cache)s"
+                     %(valid)s
+                     %(cache)s
                      entityID="%(entity_id)s">
     <md:SPSSODescriptor AuthnRequestsSigned="%(authnsign)s" WantAssertionsSigned="%(wsign)s" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         %(sls)s
@@ -139,8 +142,8 @@ class OneLogin_Saml2_Metadata(object):
 %(contacts)s
 </md:EntityDescriptor>""" % \
             {
-                'valid': valid_until_time,
-                'cache': cache_duration_str,
+                'valid': ('validUntil="%s"' % valid_until_str) if valid_until_str else '',
+                'cache': ('cacheDuration="%s"' % cache_duration_str) if cache_duration_str else '',
                 'entity_id': sp['entityId'],
                 'authnsign': str_authnsign,
                 'wsign': str_wsign,

--- a/src/onelogin/saml2/metadata.py
+++ b/src/onelogin/saml2/metadata.py
@@ -119,13 +119,18 @@ class OneLogin_Saml2_Metadata(object):
                 contacts_info.append(contact)
             str_contacts = '\n'.join(contacts_info)
 
+        str_nameid_formats = ''
+        for name_id_format in sp['NameIDFormats']:
+            str_nameid_formats += '        <md:NameIDFormat>%s</md:NameIDFormat>\n' % name_id_format
+
         metadata = """<?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
                      validUntil="%(valid)s"
                      cacheDuration="%(cache)s"
                      entityID="%(entity_id)s">
     <md:SPSSODescriptor AuthnRequestsSigned="%(authnsign)s" WantAssertionsSigned="%(wsign)s" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-%(sls)s        <md:NameIDFormat>%(name_id_format)s</md:NameIDFormat>
+        %(sls)s
+        %(str_nameid_formats)s
         <md:AssertionConsumerService Binding="%(binding)s"
                                      Location="%(location)s"
                                      index="1" />
@@ -139,7 +144,7 @@ class OneLogin_Saml2_Metadata(object):
                 'entity_id': sp['entityId'],
                 'authnsign': str_authnsign,
                 'wsign': str_wsign,
-                'name_id_format': sp['NameIDFormat'],
+                'str_nameid_formats': str_nameid_formats,
                 'binding': sp['assertionConsumerService']['binding'],
                 'location': sp['assertionConsumerService']['url'],
                 'sls': sls,

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -287,7 +287,7 @@ class OneLogin_Saml2_Response(object):
             if nameid_nodes:
                 nameid = nameid_nodes[0]
         if nameid is None:
-            raise Exception('Not NameID found in the assertion of the Response')
+            return {'Value': None}
 
         nameid_data = {'Value': nameid.text}
         for attr in ['Format', 'SPNameQualifier', 'NameQualifier']:

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -576,9 +576,21 @@ class OneLogin_Saml2_Settings(object):
         # Sign metadata
         if 'signMetadata' in self.__security and self.__security['signMetadata'] is not False:
             if self.__security['signMetadata'] is True:
-                key_file_name = 'sp.key'
-                cert_file_name = 'sp.crt'
+                # Use the SP's normal key to sign the metadata:
+                if not cert:
+                    raise OneLogin_Saml2_Error(
+                        'Cannot sign metadata: missing SP public key certificate.',
+                        OneLogin_Saml2_Error.PUBLIC_CERT_FILE_NOT_FOUND
+                    )
+                cert_metadata = cert
+                key_metadata = self.get_sp_key()
+                if not key_metadata:
+                    raise OneLogin_Saml2_Error(
+                        'Cannot sign metadata: missing SP private key.',
+                        OneLogin_Saml2_Error.PRIVATE_KEY_FILE_NOT_FOUND
+                    )
             else:
+                # Use a custom key to sign the metadata:
                 if ('keyFileName' not in self.__security['signMetadata'] or
                         'certFileName' not in self.__security['signMetadata']):
                     raise OneLogin_Saml2_Error(
@@ -587,30 +599,28 @@ class OneLogin_Saml2_Settings(object):
                     )
                 key_file_name = self.__security['signMetadata']['keyFileName']
                 cert_file_name = self.__security['signMetadata']['certFileName']
-            key_metadata_file = self.__paths['cert'] + key_file_name
-            cert_metadata_file = self.__paths['cert'] + cert_file_name
+                key_metadata_file = self.__paths['cert'] + key_file_name
+                cert_metadata_file = self.__paths['cert'] + cert_file_name
 
-            if not exists(key_metadata_file):
-                raise OneLogin_Saml2_Error(
-                    'Private key file not found: %s',
-                    OneLogin_Saml2_Error.PRIVATE_KEY_FILE_NOT_FOUND,
-                    key_metadata_file
-                )
+                try:
+                    with open(key_metadata_file, 'r') as f_metadata_key:
+                        key_metadata = f_metadata_key.read()
+                except IOError:
+                    raise OneLogin_Saml2_Error(
+                        'Private key file not readable: %s',
+                        OneLogin_Saml2_Error.PRIVATE_KEY_FILE_NOT_FOUND,
+                        key_metadata_file
+                    )
 
-            if not exists(cert_metadata_file):
-                raise OneLogin_Saml2_Error(
-                    'Public cert file not found: %s',
-                    OneLogin_Saml2_Error.PUBLIC_CERT_FILE_NOT_FOUND,
-                    cert_metadata_file
-                )
-
-            f_metadata_key = open(key_metadata_file, 'r')
-            key_metadata = f_metadata_key.read()
-            f_metadata_key.close()
-
-            f_metadata_cert = open(cert_metadata_file, 'r')
-            cert_metadata = f_metadata_cert.read()
-            f_metadata_cert.close()
+                try:
+                    with open(cert_metadata_file, 'r') as f_metadata_cert:
+                        cert_metadata = f_metadata_cert.read()
+                except IOError:
+                    raise OneLogin_Saml2_Error(
+                        'Public cert file not readable: %s',
+                        OneLogin_Saml2_Error.PUBLIC_CERT_FILE_NOT_FOUND,
+                        cert_metadata_file
+                    )
 
             metadata = OneLogin_Saml2_Metadata.sign_metadata(metadata, key_metadata, cert_metadata)
 

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -277,6 +277,12 @@ class OneLogin_Saml2_Settings(object):
         if 'nameIdEncrypted' not in self.__security:
             self.__security['nameIdEncrypted'] = False
 
+        # Metadata format
+        if 'metadataValidUntil' not in self.__security.keys():
+            self.__security['metadataValidUntil'] = None  # None means use default
+        if 'metadataCacheDuration' not in self.__security.keys():
+            self.__security['metadataCacheDuration'] = None  # None means use default
+
         # Sign provided
         if 'authnRequestsSigned' not in self.__security.keys():
             self.__security['authnRequestsSigned'] = False
@@ -559,7 +565,9 @@ class OneLogin_Saml2_Settings(object):
         """
         metadata = OneLogin_Saml2_Metadata.builder(
             self.__sp, self.__security['authnRequestsSigned'],
-            self.__security['wantAssertionsSigned'], None, None,
+            self.__security['wantAssertionsSigned'],
+            self.__security['metadataValidUntil'],
+            self.__security['metadataCacheDuration'],
             self.get_contacts(), self.get_organization()
         )
         cert = self.get_sp_cert()

--- a/src/onelogin/saml2/settings.py
+++ b/src/onelogin/saml2/settings.py
@@ -261,8 +261,19 @@ class OneLogin_Saml2_Settings(object):
             self.__sp['singleLogoutService']['binding'] = OneLogin_Saml2_Constants.BINDING_HTTP_REDIRECT
 
         # Related to nameID
-        if 'NameIDFormat' not in self.__sp:
-            self.__sp['NameIDFormat'] = OneLogin_Saml2_Constants.NAMEID_PERSISTENT
+        if 'NameIDFormats' not in self.__sp:
+            # Check if the older config setting, single NameIDFormat is present:
+            if 'NameIDFormat' in self.__sp:
+                self.__sp['NameIDFormats'] = [self.__sp['NameIDFormat']]
+            else:
+                self.__sp['NameIDFormats'] = [OneLogin_Saml2_Constants.NAMEID_PERSISTENT]
+        if 'NameIDPolicyFormat' not in self.__idp:
+            # Check for the old-style setting 'NameIDFormat' which set both NameIDFormats and NameIDPolicyFormat:
+            if 'NameIDFormat' in self.__sp:
+                self.__idp['NameIDPolicyFormat'] = self.__sp.pop('NameIDFormat')
+                self.__idp['NameIDPolicyAllowCreate'] = True
+        if 'NameIDPolicyAllowCreate' not in self.__idp:
+            self.__idp['NameIDPolicyAllowCreate'] = False  # False is the default according to the spec
         if 'nameIdEncrypted' not in self.__security:
             self.__security['nameIdEncrypted'] = False
 

--- a/tests/settings/settings1.json
+++ b/tests/settings/settings1.json
@@ -10,7 +10,7 @@
         "singleLogoutService": {
             "url": "http://stuff.com/endpoints/endpoints/sls.php"
         },
-        "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
+        "NameIDFormats": ["urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"]
     },
     "idp": {
         "entityId": "http://idp.example.com/",
@@ -20,6 +20,8 @@
         "singleLogoutService": {
             "url": "http://idp.example.com/SingleLogoutService.php"
         },
+        "NameIDPolicyFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+        "NameIDPolicyAllowCreate": true,
         "x509cert": "MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo"
     },
     "security": {

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -64,7 +64,7 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
 
         security['authnRequestsSigned'] = True
         security['wantAssertionsSigned'] = True
-        del sp_data['singleLogoutService']
+        del sp_data['singleLogoutService']['url']
 
         metadata2 = OneLogin_Saml2_Metadata.builder(
             sp_data, security['authnRequestsSigned'],

--- a/tests/src/OneLogin/saml2_tests/metadata_test.py
+++ b/tests/src/OneLogin/saml2_tests/metadata_test.py
@@ -84,14 +84,42 @@ class OneLogin_Saml2_Metadata_Test(unittest.TestCase):
             sp_data, security['authnRequestsSigned'],
             security['wantAssertionsSigned'],
             '2014-10-01T11:04:29Z',
-            'PT1412593469S',
+            'P1Y',
             contacts,
             organization
         )
         self.assertIsNotNone(metadata3)
         self.assertIn('<md:SPSSODescriptor', metadata3)
-        self.assertIn('cacheDuration="PT1412593469S"', metadata3)
+        self.assertIn('cacheDuration="P1Y"', metadata3)
         self.assertIn('validUntil="2014-10-01T11:04:29Z"', metadata3)
+
+        # Test no validUntil, only cacheDuration:
+        metadata4 = OneLogin_Saml2_Metadata.builder(
+            sp_data, security['authnRequestsSigned'],
+            security['wantAssertionsSigned'],
+            '',
+            86400 * 10,  # 10 days
+            contacts,
+            organization
+        )
+        self.assertIsNotNone(metadata4)
+        self.assertIn('<md:SPSSODescriptor', metadata4)
+        self.assertIn('cacheDuration="PT864000S"', metadata4)
+        self.assertNotIn('validUntil', metadata4)
+
+        # Test no cacheDuration, only validUntil:
+        metadata5 = OneLogin_Saml2_Metadata.builder(
+            sp_data, security['authnRequestsSigned'],
+            security['wantAssertionsSigned'],
+            '2014-10-01T11:04:29Z',
+            '',
+            contacts,
+            organization
+        )
+        self.assertIsNotNone(metadata5)
+        self.assertIn('<md:SPSSODescriptor', metadata5)
+        self.assertNotIn('cacheDuration', metadata5)
+        self.assertIn('validUntil="2014-10-01T11:04:29Z"', metadata5)
 
     def testSignMetadata(self):
         """

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -74,11 +74,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_nameid.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
-            response_4.get_nameid()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', e.message)
+        self.assertIsNone(response_4.get_nameid())
 
     def testGetNameIdData(self):
         """
@@ -116,11 +112,8 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_nameid.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        try:
-            response_4.get_nameid_data()
-            self.assertTrue(False)
-        except Exception as e:
-            self.assertIn('Not NameID found in the assertion of the Response', e.message)
+        data = response_4.get_nameid_data()
+        self.assertEqual(data, {'Value': None})
 
     def testCheckStatus(self):
         """

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -7,6 +7,7 @@ import json
 from os.path import dirname, join, exists, sep
 import unittest
 
+from onelogin.saml2.errors import OneLogin_Saml2_Error
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
@@ -373,8 +374,24 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         if 'security' not in settings_info:
             settings_info['security'] = {}
         settings_info['security']['signMetadata'] = True
-        settings = OneLogin_Saml2_Settings(settings_info)
+        self.generateAndCheckMetadata(settings_info)
 
+        # Now try again with SP keys set directly in settings and not from files:
+        del settings_info['custom_base_path']
+        # Now the keys should not be found, so metadata generation won't work:
+        with self.assertRaises(OneLogin_Saml2_Error):
+            OneLogin_Saml2_Settings(settings_info).get_sp_metadata()
+        # Set the keys in the settings:
+        settings_info['sp']['x509cert'] = self.file_contents(join(self.data_path, 'customPath', 'certs', 'sp.crt'))
+        settings_info['sp']['privateKey'] = self.file_contents(join(self.data_path, 'customPath', 'certs', 'sp.key'))
+        self.generateAndCheckMetadata(settings_info)
+
+    def generateAndCheckMetadata(self, settings):
+        """
+        Helper method: Given some settings, generate metadata and validate it
+        """
+        if not isinstance(settings, OneLogin_Saml2_Settings):
+            settings = OneLogin_Saml2_Settings(settings)
         metadata = settings.get_sp_metadata()
         self.assertIn('<md:SPSSODescriptor', metadata)
         self.assertIn('entityID="http://stuff.com/endpoints/metadata.php"', metadata)
@@ -387,6 +404,7 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         self.assertIn('<ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>', metadata)
         self.assertIn('<ds:Reference', metadata)
         self.assertIn('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', metadata)
+        return metadata
 
     def testGetSPMetadataSignedNoMetadataCert(self):
         """
@@ -413,7 +431,7 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
             settings.get_sp_metadata()
             self.assertTrue(False)
         except Exception as e:
-            self.assertIn('Private key file not found', e.message)
+            self.assertIn('Private key file not readable', e.message)
 
         settings_info['security']['signMetadata'] = {
             'keyFileName': 'sp.key',
@@ -424,7 +442,7 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
             settings.get_sp_metadata()
             self.assertTrue(False)
         except Exception as e:
-            self.assertIn('Public cert file not found', e.message)
+            self.assertIn('Public cert file not readable', e.message)
 
         settings_info['security']['signMetadata'] = 'invalid_value'
         settings = OneLogin_Saml2_Settings(settings_info)

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -49,7 +49,9 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         settings = OneLogin_Saml2_Settings(settings_info)
         self.assertEqual(len(settings.get_errors()), 0)
 
-        del settings_info['sp']['NameIDFormat']
+        del settings_info['sp']['NameIDFormats']
+        del settings_info['idp']['NameIDPolicyFormat']
+        del settings_info['idp']['NameIDPolicyAllowCreate']
         del settings_info['idp']['x509cert']
         settings_info['idp']['certFingerprint'] = 'afe71c28ef740bc87425be13a2263d37971daA1f9'
         settings = OneLogin_Saml2_Settings(settings_info)
@@ -507,11 +509,15 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         self.assertIn('entityId', idp_data)
         self.assertIn('singleSignOnService', idp_data)
         self.assertIn('singleLogoutService', idp_data)
+        self.assertIn('NameIDPolicyFormat', idp_data)
+        self.assertIn('NameIDPolicyAllowCreate', idp_data)
         self.assertIn('x509cert', idp_data)
 
         self.assertEqual('http://idp.example.com/', idp_data['entityId'])
         self.assertEqual('http://idp.example.com/SSOService.php', idp_data['singleSignOnService']['url'])
         self.assertEqual('http://idp.example.com/SingleLogoutService.php', idp_data['singleLogoutService']['url'])
+        self.assertEqual('urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified', idp_data['NameIDPolicyFormat'])
+        self.assertTrue(idp_data['NameIDPolicyAllowCreate'])
 
         x509cert = 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo'
         formated_x509_cert = OneLogin_Saml2_Utils.format_cert(x509cert)
@@ -528,12 +534,12 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         self.assertIn('entityId', sp_data)
         self.assertIn('assertionConsumerService', sp_data)
         self.assertIn('singleLogoutService', sp_data)
-        self.assertIn('NameIDFormat', sp_data)
+        self.assertIn('NameIDFormats', sp_data)
 
         self.assertEqual('http://stuff.com/endpoints/metadata.php', sp_data['entityId'])
         self.assertEqual('http://stuff.com/endpoints/endpoints/acs.php', sp_data['assertionConsumerService']['url'])
         self.assertEqual('http://stuff.com/endpoints/endpoints/sls.php', sp_data['singleLogoutService']['url'])
-        self.assertEqual('urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified', sp_data['NameIDFormat'])
+        self.assertEqual(['urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified'], sp_data['NameIDFormats'])
 
     def testGetSecurityData(self):
         """


### PR DESCRIPTION
This PR contains four minor changes/fixes that we require to use python-saml with python-social-auth and the edX platform.

Each change includes tests, passes tests/CI, should be backwards-compatible, and is in an independent commit.
##### 1. Make singleLogoutService optional

Currently, if one wishes to generate SAML metadata using:

``` python
saml_settings = OneLogin_Saml2_Settings(config)
metadata = saml_settings.get_sp_metadata()
```

an error will occur if your settings do not specify a `singleLogoutService` URL. This is meant to be optional, but the settings parser always adds an empty `singleLogoutService` dict to the settings dict, which gets interpreted by other parts of the code as meaning that `singleLogoutService` should be used. The fix checks for the presence of `settings['singleLogoutService']['url']`, which should only be present when the user actually wants to use a `singleLogoutService`.
##### 2. NameID Changes

Currently, python-saml has only one setting, "NameIDFormat" to control NameIDs. I have made a few changes:

A. For the SP, the `NameIDFormat` (string) setting is replaced with `NameIDFormats` (list), because [the SAML spec](http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) says the `NameIDFormat` can be specified zero or more times (0,1,2,3,4, ...) and is intended to list _all_ NameID formats accepted by the SP. As we need to work with multiple IdPs, it is important that we can configure our metadata to list many accepted formats, or none at all. For backwards compatibility, the `NameIDFormat` (string) setting will still be accepted.
B. `NameIDPolicyFormat` and `NameIDPolicyAllowCreate` are two new settings to control the optional `NameIDPolicy` element in authn requests. If the old `NameIDFormat` setting is used, these will automatically be set to match. Otherwise, the new default is to not specify a `NameIDPolicy` at all, which is the default stated [in the spec](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). I also put these policy settings in the `idp` settings, so that they can be changed per-provider for those working with multiple IdPs.
##### 3. Allow configuration of metadata caching/expiry via settings

Curently, python-saml does not allow users to set the time period for which metadata is valid using settings. I have added two new settings to allow the user to control the default expiry date and/or maximum cache time. In addition, you can opt to leave one, the other, or both unspecified. Although leaving both unspecified is against the spec, it is commonly done and is helpful for integration tests and development environments.

I also found and fixed a bug: the `cacheDuration` attribute in the XML is supposed to be a duration value like `PT86400S` (Period of Time 86400 Seconds - i.e. one day), and IdP implementations are required to record the time at which they fetched the metadata in order to compute the cache expiry time. However, the code was instead putting an absolute timestamp in this field, which would get interpreted as an extremely long maximum cache time (45+ years).
##### 4. Allow metadata signing with SP key specified as config value

This is a simple one: If python-saml is configured to sign metadata using the same key that it uses as an SP, it would only work if the key was present as a file on disk. If the SP key was specified as a string value directly in settings, the metadata signing would give an error.

This is a contribution from edX, developed by OpenCraft as part of bringing integrated SAML support to the edX platform.
