### PR TITLE
Use more detailed exceptions when possible

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -57,6 +57,8 @@ class OneLogin_Saml2_Auth(object):
         self.__errors = []
         self.__error_reason = None
         self.__last_request_id = None
+        self.__last_request_xml = None
+        self.__last_response = None
 
     def get_settings(self):
         """
@@ -90,6 +92,7 @@ class OneLogin_Saml2_Auth(object):
         if 'post_data' in self.__request_data and 'SAMLResponse' in self.__request_data['post_data']:
             # AuthnResponse -- HTTP_POST Binding
             response = OneLogin_Saml2_Response(self.__settings, self.__request_data['post_data']['SAMLResponse'])
+            self.__last_response = response.get_document()
 
             if response.is_valid(self.__request_data, request_id):
                 self.__attributes = response.get_attributes()
@@ -290,6 +293,7 @@ class OneLogin_Saml2_Auth(object):
 
         saml_request = authn_request.get_request()
         parameters = {'SAMLRequest': saml_request}
+        self.__last_request_xml = authn_request.get_request_as_xml()
 
         if return_to is not None:
             parameters['RelayState'] = return_to
@@ -451,3 +455,9 @@ class OneLogin_Saml2_Auth(object):
 
         signature = dsig_ctx.signBinary(str(msg), sign_algorithm_transform)
         return b64encode(signature)
+
+    def get_last_response_xml(self):
+        return self.__last_response
+
+    def get_last_request_xml(self):
+        return self.__last_request_xml

--- a/src/onelogin/saml2/authn_request.py
+++ b/src/onelogin/saml2/authn_request.py
@@ -142,6 +142,9 @@ class OneLogin_Saml2_Authn_Request(object):
             request = b64encode(self.__authn_request)
         return request
 
+    def get_request_as_xml(self):
+        return self.__authn_request
+
     def get_id(self):
         """
         Returns the AuthNRequest ID.

--- a/src/onelogin/saml2/authn_request.py
+++ b/src/onelogin/saml2/authn_request.py
@@ -143,6 +143,9 @@ class OneLogin_Saml2_Authn_Request(object):
         return request
 
     def get_request_as_xml(self):
+        """
+        Return the XML document that will be sent as part of the request
+        """
         return self.__authn_request
 
     def get_id(self):

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -552,6 +552,9 @@ class OneLogin_Saml2_Response(object):
         return self.__error
 
     def get_document(self):
+        """
+        If necessary, decrypt the XML response document, and return it.
+        """
         if self.encrypted:
             return self.decrypted_document
         else:

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -210,7 +210,7 @@ class OneLogin_Saml2_Response(object):
                         document_to_validate = self.decrypted_document
                     else:
                         document_to_validate = self.document
-                OneLogin_Saml2_Utils.validate_sign(document_to_validate, cert, fingerprint, fingerprintalg):
+                OneLogin_Saml2_Utils.validate_sign(document_to_validate, cert, fingerprint, fingerprintalg)
             else:
                 raise Exception('No Signature found. SAML Response rejected')
 

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -888,50 +888,47 @@ class OneLogin_Saml2_Utils(object):
         :param debug: Activate the xmlsec debug
         :type: bool
         """
-        try:
-            if xml is None or xml == '':
-                raise Exception('Empty string supplied as input')
-            elif isinstance(xml, etree._Element):
-                elem = xml
-            elif isinstance(xml, Document):
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, Element):
-                xml.setAttributeNS(
-                    unicode(OneLogin_Saml2_Constants.NS_SAMLP),
-                    'xmlns:samlp',
-                    unicode(OneLogin_Saml2_Constants.NS_SAMLP)
-                )
-                xml.setAttributeNS(
-                    unicode(OneLogin_Saml2_Constants.NS_SAML),
-                    'xmlns:saml',
-                    unicode(OneLogin_Saml2_Constants.NS_SAML)
-                )
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, basestring):
-                elem = fromstring(str(xml))
-            else:
-                raise Exception('Error parsing xml string')
+        if xml is None or xml == '':
+            raise Exception('Validating signature failed: Empty string supplied as input')
+        elif isinstance(xml, etree._Element):
+            elem = xml
+        elif isinstance(xml, Document):
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, Element):
+            xml.setAttributeNS(
+                unicode(OneLogin_Saml2_Constants.NS_SAMLP),
+                'xmlns:samlp',
+                unicode(OneLogin_Saml2_Constants.NS_SAMLP)
+            )
+            xml.setAttributeNS(
+                unicode(OneLogin_Saml2_Constants.NS_SAML),
+                'xmlns:saml',
+                unicode(OneLogin_Saml2_Constants.NS_SAML)
+            )
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, basestring):
+            elem = fromstring(str(xml))
+        else:
+            raise Exception('Validating siganture failed: Error parsing xml string')
 
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
 
-            xmlsec.addIDs(elem, ["ID"])
+        xmlsec.addIDs(elem, ["ID"])
 
-            signature_nodes = OneLogin_Saml2_Utils.query(elem, '/samlp:Response/ds:Signature')
+        signature_nodes = OneLogin_Saml2_Utils.query(elem, '/samlp:Response/ds:Signature')
 
-            if not len(signature_nodes) > 0:
-                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/samlp:Response/saml:Assertion/ds:Signature')
+        if not len(signature_nodes) > 0:
+            signature_nodes += OneLogin_Saml2_Utils.query(elem, '/samlp:Response/saml:Assertion/ds:Signature')
 
-            if len(signature_nodes) == 1:
-                signature_node = signature_nodes[0]
+        if len(signature_nodes) == 1:
+            signature_node = signature_nodes[0]
 
-                return OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug)
-            else:
-                return False
-        except Exception:
-            return False
+            return OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug)
+        else:
+            raise Exception('Validating signature failed: 1 signature node expected; {} received'.format(len(signature_nodes)))
 
     @staticmethod
     def validate_metadata_sign(xml, cert=None, fingerprint=None, fingerprintalg='sha1', validatecert=False, debug=False):
@@ -956,50 +953,46 @@ class OneLogin_Saml2_Utils(object):
         :param debug: Activate the xmlsec debug
         :type: bool
         """
-        try:
-            if xml is None or xml == '':
-                raise Exception('Empty string supplied as input')
-            elif isinstance(xml, etree._Element):
-                elem = xml
-            elif isinstance(xml, Document):
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, Element):
-                xml.setAttributeNS(
-                    unicode(OneLogin_Saml2_Constants.NS_MD),
-                    'xmlns:md',
-                    unicode(OneLogin_Saml2_Constants.NS_MD)
-                )
-                xml = xml.toxml()
-                elem = fromstring(str(xml))
-            elif isinstance(xml, basestring):
-                elem = fromstring(str(xml))
-            else:
-                raise Exception('Error parsing xml string')
+        if xml is None or xml == '':
+            raise Exception('Empty string supplied as input')
+        elif isinstance(xml, etree._Element):
+            elem = xml
+        elif isinstance(xml, Document):
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, Element):
+            xml.setAttributeNS(
+                unicode(OneLogin_Saml2_Constants.NS_MD),
+                'xmlns:md',
+                unicode(OneLogin_Saml2_Constants.NS_MD)
+            )
+            xml = xml.toxml()
+            elem = fromstring(str(xml))
+        elif isinstance(xml, basestring):
+            elem = fromstring(str(xml))
+        else:
+            raise Exception('Error parsing xml string')
 
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
 
-            xmlsec.addIDs(elem, ["ID"])
+        xmlsec.addIDs(elem, ["ID"])
 
-            signature_nodes = OneLogin_Saml2_Utils.query(elem, '/md:EntitiesDescriptor/ds:Signature')
+        signature_nodes = OneLogin_Saml2_Utils.query(elem, '/md:EntitiesDescriptor/ds:Signature')
+
+        if len(signature_nodes) == 0:
+            signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/ds:Signature')
 
             if len(signature_nodes) == 0:
-                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/ds:Signature')
+                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:SPSSODescriptor/ds:Signature')
+                signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:IDPSSODescriptor/ds:Signature')
 
-                if len(signature_nodes) == 0:
-                    signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:SPSSODescriptor/ds:Signature')
-                    signature_nodes += OneLogin_Saml2_Utils.query(elem, '/md:EntityDescriptor/md:IDPSSODescriptor/ds:Signature')
-
-            if len(signature_nodes) > 0:
-                for signature_node in signature_nodes:
-                    if not OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug):
-                        return False
-                return True
-            else:
-                return False
-        except Exception:
-            return False
+        if len(signature_nodes) > 0:
+            for signature_node in signature_nodes:
+                OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug):
+            return True
+        else:
+            raise Exception('Expected at least one signature node; none found.')
 
     @staticmethod
     def validate_node_sign(signature_node, elem, cert=None, fingerprint=None, fingerprintalg='sha1', validatecert=False, debug=False):
@@ -1027,47 +1020,44 @@ class OneLogin_Saml2_Utils(object):
         :param debug: Activate the xmlsec debug
         :type: bool
         """
-        try:
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
 
-            xmlsec.addIDs(elem, ["ID"])
+        xmlsec.addIDs(elem, ["ID"])
 
-            if (cert is None or cert == '') and fingerprint:
-                x509_certificate_nodes = OneLogin_Saml2_Utils.query(signature_node, '//ds:Signature/ds:KeyInfo/ds:X509Data/ds:X509Certificate')
-                if len(x509_certificate_nodes) > 0:
-                    x509_certificate_node = x509_certificate_nodes[0]
-                    x509_cert_value = x509_certificate_node.text
-                    x509_fingerprint_value = OneLogin_Saml2_Utils.calculate_x509_fingerprint(x509_cert_value, fingerprintalg)
-                    if fingerprint == x509_fingerprint_value:
-                        cert = OneLogin_Saml2_Utils.format_cert(x509_cert_value)
+        if (cert is None or cert == '') and fingerprint:
+            x509_certificate_nodes = OneLogin_Saml2_Utils.query(signature_node, '//ds:Signature/ds:KeyInfo/ds:X509Data/ds:X509Certificate')
+            if len(x509_certificate_nodes) > 0:
+                x509_certificate_node = x509_certificate_nodes[0]
+                x509_cert_value = x509_certificate_node.text
+                x509_fingerprint_value = OneLogin_Saml2_Utils.calculate_x509_fingerprint(x509_cert_value, fingerprintalg)
+                if fingerprint == x509_fingerprint_value:
+                    cert = OneLogin_Saml2_Utils.format_cert(x509_cert_value)
 
-            # Check if Reference URI is empty
-            # reference_elem = OneLogin_Saml2_Utils.query(signature_node, '//ds:Reference')
-            # if len(reference_elem) > 0:
-            #    if reference_elem[0].get('URI') == '':
-            #        reference_elem[0].set('URI', '#%s' % signature_node.getparent().get('ID'))
+        # Check if Reference URI is empty
+        # reference_elem = OneLogin_Saml2_Utils.query(signature_node, '//ds:Reference')
+        # if len(reference_elem) > 0:
+        #    if reference_elem[0].get('URI') == '':
+        #        reference_elem[0].set('URI', '#%s' % signature_node.getparent().get('ID'))
 
-            if cert is None or cert == '':
-                return False
+        if cert is None or cert == '':
+            raise Exception('Validating signature failed: No certificate provided')
 
-            file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
+        file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
 
-            if validatecert:
-                mngr = xmlsec.KeysMngr()
-                mngr.loadCert(file_cert.name, xmlsec.KeyDataFormatCertPem, xmlsec.KeyDataTypeTrusted)
-                dsig_ctx = xmlsec.DSigCtx(mngr)
-            else:
-                dsig_ctx = xmlsec.DSigCtx()
-                dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
+        if validatecert:
+            mngr = xmlsec.KeysMngr()
+            mngr.loadCert(file_cert.name, xmlsec.KeyDataFormatCertPem, xmlsec.KeyDataTypeTrusted)
+            dsig_ctx = xmlsec.DSigCtx(mngr)
+        else:
+            dsig_ctx = xmlsec.DSigCtx()
+            dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
 
-            file_cert.close()
+        file_cert.close()
 
-            dsig_ctx.setEnabledKeyData([xmlsec.KeyDataX509])
-            dsig_ctx.verify(signature_node)
-            return True
-        except Exception:
-            return False
+        dsig_ctx.setEnabledKeyData([xmlsec.KeyDataX509])
+        dsig_ctx.verify(signature_node)
+        return True
 
     @staticmethod
     def validate_binary_sign(signed_query, signature, cert=None, algorithm=OneLogin_Saml2_Constants.RSA_SHA1, debug=False):
@@ -1090,30 +1080,27 @@ class OneLogin_Saml2_Utils(object):
         :param debug: Activate the xmlsec debug
         :type: bool
         """
-        try:
-            if debug:
-                xmlsec.set_error_callback(print_xmlsec_errors)
+        if debug:
+            xmlsec.set_error_callback(print_xmlsec_errors)
 
-            dsig_ctx = xmlsec.DSigCtx()
+        dsig_ctx = xmlsec.DSigCtx()
 
-            file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
-            dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
-            file_cert.close()
+        file_cert = OneLogin_Saml2_Utils.write_temp_file(cert)
+        dsig_ctx.signKey = xmlsec.Key.load(file_cert.name, xmlsec.KeyDataFormatCertPem, None)
+        file_cert.close()
 
-            # Sign the metadata with our private key.
-            sign_algorithm_transform_map = {
-                OneLogin_Saml2_Constants.DSA_SHA1: xmlsec.TransformDsaSha1,
-                OneLogin_Saml2_Constants.RSA_SHA1: xmlsec.TransformRsaSha1,
-                OneLogin_Saml2_Constants.RSA_SHA256: xmlsec.TransformRsaSha256,
-                OneLogin_Saml2_Constants.RSA_SHA384: xmlsec.TransformRsaSha384,
-                OneLogin_Saml2_Constants.RSA_SHA512: xmlsec.TransformRsaSha512
-            }
-            sign_algorithm_transform = sign_algorithm_transform_map.get(algorithm, xmlsec.TransformRsaSha1)
+        # Sign the metadata with our private key.
+        sign_algorithm_transform_map = {
+            OneLogin_Saml2_Constants.DSA_SHA1: xmlsec.TransformDsaSha1,
+            OneLogin_Saml2_Constants.RSA_SHA1: xmlsec.TransformRsaSha1,
+            OneLogin_Saml2_Constants.RSA_SHA256: xmlsec.TransformRsaSha256,
+            OneLogin_Saml2_Constants.RSA_SHA384: xmlsec.TransformRsaSha384,
+            OneLogin_Saml2_Constants.RSA_SHA512: xmlsec.TransformRsaSha512
+        }
+        sign_algorithm_transform = sign_algorithm_transform_map.get(algorithm, xmlsec.TransformRsaSha1)
 
-            dsig_ctx.verifyBinary(signed_query, sign_algorithm_transform, signature)
-            return True
-        except Exception:
-            return False
+        dsig_ctx.verifyBinary(signed_query, sign_algorithm_transform, signature)
+        return True
 
     @staticmethod
     def get_encoded_parameter(get_data, name, default=None, lowercase_urlencoding=False):

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -989,7 +989,7 @@ class OneLogin_Saml2_Utils(object):
 
         if len(signature_nodes) > 0:
             for signature_node in signature_nodes:
-                OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug):
+                OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug)
             return True
         else:
             raise Exception('Expected at least one signature node; none found.')

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -125,7 +125,6 @@ class OneLogin_Saml2_Utils(object):
             if debug:
                 stderr.write('Errors validating the metadata')
                 stderr.write(':\n\n')
-                exception_text = 'Failed to validate metadata with errors: \n'
                 for error in xmlschema.error_log:
                     stderr.write('%s\n' % error.message)
 
@@ -790,7 +789,7 @@ class OneLogin_Saml2_Utils(object):
         :type sign_algorithm: string
         """
         if xml is None or xml == '':
-            raise Exception('Empty string supplied as input')
+            raise Exception('Adding signature failed: Empty string supplied as input')
         elif isinstance(xml, etree._Element):
             elem = xml
         elif isinstance(xml, Document):
@@ -812,7 +811,7 @@ class OneLogin_Saml2_Utils(object):
         elif isinstance(xml, basestring):
             elem = fromstring(str(xml))
         else:
-            raise Exception('Error parsing xml string')
+            raise Exception('Adding signature failed: Error parsing xml string')
 
         if debug:
             xmlsec.set_error_callback(print_xmlsec_errors)
@@ -915,7 +914,7 @@ class OneLogin_Saml2_Utils(object):
         elif isinstance(xml, basestring):
             elem = fromstring(str(xml))
         else:
-            raise Exception('Validating siganture failed: Error parsing xml string')
+            raise Exception('Validating signature failed: Error parsing xml string')
 
         if debug:
             xmlsec.set_error_callback(print_xmlsec_errors)
@@ -958,7 +957,7 @@ class OneLogin_Saml2_Utils(object):
         :type: bool
         """
         if xml is None or xml == '':
-            raise Exception('Empty string supplied as input')
+            raise Exception('Validating metadata failed: Empty string supplied as input')
         elif isinstance(xml, etree._Element):
             elem = xml
         elif isinstance(xml, Document):
@@ -975,7 +974,7 @@ class OneLogin_Saml2_Utils(object):
         elif isinstance(xml, basestring):
             elem = fromstring(str(xml))
         else:
-            raise Exception('Error parsing xml string')
+            raise Exception('Validating metadata failed: Error parsing xml string')
 
         if debug:
             xmlsec.set_error_callback(print_xmlsec_errors)
@@ -996,7 +995,7 @@ class OneLogin_Saml2_Utils(object):
                 OneLogin_Saml2_Utils.validate_node_sign(signature_node, elem, cert, fingerprint, fingerprintalg, validatecert, debug)
             return True
         else:
-            raise Exception('Expected at least one signature node; none found.')
+            raise Exception('Validating metadata failed: Expected at least one signature node; none found.')
 
     @staticmethod
     def validate_node_sign(signature_node, elem, cert=None, fingerprint=None, fingerprintalg='sha1', validatecert=False, debug=False):

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -125,10 +125,14 @@ class OneLogin_Saml2_Utils(object):
             if debug:
                 stderr.write('Errors validating the metadata')
                 stderr.write(':\n\n')
+                exception_text = 'Failed to validate metadata with errors: \n'
                 for error in xmlschema.error_log:
                     stderr.write('%s\n' % error.message)
 
-            return 'invalid_xml'
+            exception_text = 'Failed to validate metadata with errors: \n'
+            for error in xmlschema.error_log:
+                exception_text += 'Line {error.line}: {error.message}\n'.format(error=error)
+            raise Exception(exception_text)
 
         return parseString(etree.tostring(dom))
 

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -133,7 +133,7 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         auth = OneLogin_Saml2_Auth(request_data, old_settings=self.loadSettingsJSON())
         auth.process_response()
 
-        self.assertEqual(auth.get_last_error_reason(), 'Signature validation failed. SAML Response rejected')
+        self.assertEqual(auth.get_last_error_reason(), "('signature verification failed', 2)")
 
     def testProcessNoResponse(self):
         """

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -403,7 +403,15 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         settings.set_strict(True)
         response_2 = OneLogin_Saml2_Response(settings, message)
         self.assertFalse(response_2.is_valid(request_data))
-        self.assertEqual('Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd', response_2.get_error())
+        self.assertEqual(
+            "Failed to validate metadata with errors: \n"
+            "Line 1: Element '{urn:oasis:names:tc:SAML:2.0:protocol}Response': The attribute 'IssueInstant' is required but missing.\n"
+            "Line 1: Element '{urn:oasis:names:tc:SAML:2.0:assertion}Assertion': The attribute 'Version' is required but missing.\n"
+            "Line 1: Element '{urn:oasis:names:tc:SAML:2.0:assertion}Assertion': The attribute 'ID' is required but missing.\n"
+            "Line 1: Element '{urn:oasis:names:tc:SAML:2.0:assertion}Assertion': The attribute 'IssueInstant' is required but missing.\n"
+            "Line 1: Element '{urn:oasis:names:tc:SAML:2.0:assertion}Assertion': Character content other than whitespace is not allowed because the content type is 'element-only'.\n"
+            "Line 1: Element '{urn:oasis:names:tc:SAML:2.0:assertion}Assertion': Missing child element(s). Expected is ( {urn:oasis:names:tc:SAML:2.0:assertion}Issuer ).\n",
+            response_2.get_error())
 
     def testValidateNumAssertions(self):
         """
@@ -416,7 +424,7 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_multi_assertion = self.file_contents(join(self.data_path, 'responses', 'invalids', 'multiple_assertions.xml.base64'))
         response_2 = OneLogin_Saml2_Response(settings, xml_multi_assertion)
-        self.assertFalse(response_2.validate_num_assertions())
+        self.assertRaises(Exception, response_2.validate_num_assertions)
 
     def testValidateTimestamps(self):
         """
@@ -433,15 +441,15 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
 
         xml_3 = self.file_contents(join(self.data_path, 'responses', 'expired_response.xml.base64'))
         response_3 = OneLogin_Saml2_Response(settings, xml_3)
-        self.assertFalse(response_3.validate_timestamps())
+        self.assertRaises(Exception, response_3.validate_timestamps)
 
         xml_4 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'not_after_failed.xml.base64'))
         response_4 = OneLogin_Saml2_Response(settings, xml_4)
-        self.assertFalse(response_4.validate_timestamps())
+        self.assertRaises(Exception, response_4.validate_timestamps)
 
         xml_5 = self.file_contents(join(self.data_path, 'responses', 'invalids', 'not_before_failed.xml.base64'))
         response_5 = OneLogin_Saml2_Response(settings, xml_5)
-        self.assertFalse(response_5.validate_timestamps())
+        self.assertRaises(Exception, response_5.validate_timestamps)
 
     def testValidateVersion(self):
         """

--- a/tests/src/OneLogin/saml2_tests/settings_test.py
+++ b/tests/src/OneLogin/saml2_tests/settings_test.py
@@ -516,7 +516,7 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         self.assertEqual(len(settings.validate_metadata(xml)), 0)
 
         xml_2 = '<xml>invalid</xml>'
-        self.assertIn('invalid_xml', settings.validate_metadata(xml_2))
+        self.assertRaises(Exception, settings.validate_metadata, xml_2)
 
         xml_3 = self.file_contents(join(self.data_path, 'metadata', 'entities_metadata.xml'))
         self.assertIn('noEntityDescriptor_xml', settings.validate_metadata(xml_3))
@@ -563,9 +563,8 @@ class OneLogin_Saml2_Settings_Test(unittest.TestCase):
         """
         settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
         metadata = self.file_contents(join(self.data_path, 'metadata', 'noentity_metadata_settings1.xml'))
-        errors = settings.validate_metadata(metadata)
         self.assertNotEqual(len(metadata), 0)
-        self.assertIn('invalid_xml', errors)
+        self.assertRaises(Exception, settings.validate_metadata, metadata)
 
     def testGetIdPData(self):
         """

--- a/tests/src/OneLogin/saml2_tests/utils_test.py
+++ b/tests/src/OneLogin/saml2_tests/utils_test.py
@@ -47,7 +47,7 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         self.assertEqual(OneLogin_Saml2_Utils.validate_xml(metadata_unloaded, 'saml-schema-metadata-2.0.xsd'), 'unloaded_xml')
 
         metadata_invalid = self.file_contents(join(self.data_path, 'metadata', 'noentity_metadata_settings1.xml'))
-        self.assertEqual(OneLogin_Saml2_Utils.validate_xml(metadata_invalid, 'saml-schema-metadata-2.0.xsd'), 'invalid_xml')
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_xml, metadata_invalid, 'saml-schema-metadata-2.0.xsd')
 
         metadata_expired = self.file_contents(join(self.data_path, 'metadata', 'expired_metadata_settings1.xml'))
         res = OneLogin_Saml2_Utils.validate_xml(metadata_expired, 'saml-schema-metadata-2.0.xsd')
@@ -58,8 +58,7 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         self.assertTrue(isinstance(res, Document))
 
         metadata_bad_order = self.file_contents(join(self.data_path, 'metadata', 'metadata_bad_order_settings1.xml'))
-        res = OneLogin_Saml2_Utils.validate_xml(metadata_bad_order, 'saml-schema-metadata-2.0.xsd')
-        self.assertFalse(isinstance(res, Document))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_xml, metadata_bad_order, 'saml-schema-metadata-2.0.xsd')
 
         metadata_signed = self.file_contents(join(self.data_path, 'metadata', 'signed_metadata_settings1.xml'))
         res = OneLogin_Saml2_Utils.validate_xml(metadata_signed, 'saml-schema-metadata-2.0.xsd')
@@ -830,7 +829,7 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         try:
             OneLogin_Saml2_Utils.add_sign(1, key, cert)
         except Exception as e:
-            self.assertEqual('Error parsing xml string', e.message)
+            self.assertEqual('Adding signature failed: Error parsing xml string', e.message)
 
     def testValidateSign(self):
         """
@@ -849,18 +848,18 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         try:
             self.assertFalse(OneLogin_Saml2_Utils.validate_sign('', cert))
         except Exception as e:
-            self.assertEqual('Empty string supplied as input', e.message)
+            self.assertEqual('Validating signature failed: Empty string supplied as input', e.message)
 
         try:
             self.assertFalse(OneLogin_Saml2_Utils.validate_sign(1, cert))
         except Exception as e:
-            self.assertEqual('Error parsing xml string', e.message)
+            self.assertEqual('Validating signature failed: Error parsing xml string', e.message)
 
         # expired cert
         xml_metadata_signed = self.file_contents(join(self.data_path, 'metadata', 'signed_metadata_settings1.xml'))
         self.assertTrue(OneLogin_Saml2_Utils.validate_metadata_sign(xml_metadata_signed, cert))
         # expired cert, verified it
-        self.assertFalse(OneLogin_Saml2_Utils.validate_metadata_sign(xml_metadata_signed, cert, validatecert=True))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_metadata_sign, xml_metadata_signed, cert, validatecert=True)
 
         xml_metadata_signed_2 = self.file_contents(join(self.data_path, 'metadata', 'signed_metadata_settings2.xml'))
         self.assertTrue(OneLogin_Saml2_Utils.validate_metadata_sign(xml_metadata_signed_2, cert_2))
@@ -871,15 +870,15 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         # expired cert
         self.assertTrue(OneLogin_Saml2_Utils.validate_sign(xml_response_msg_signed, cert))
         # expired cert, verified it
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(xml_response_msg_signed, cert, validatecert=True))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, xml_response_msg_signed, cert, validatecert=True)
 
         # modified cert
         other_cert_path = join(dirname(__file__), '..', '..', '..', 'certs')
         f = open(other_cert_path + '/certificate1', 'r')
         cert_x = f.read()
         f.close()
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(xml_response_msg_signed, cert_x))
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(xml_response_msg_signed, cert_x, validatecert=True))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, xml_response_msg_signed, cert_x)
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, xml_response_msg_signed, cert_x, validatecert=True)
 
         xml_response_msg_signed_2 = b64decode(self.file_contents(join(self.data_path, 'responses', 'signed_message_response2.xml.base64')))
         self.assertTrue(OneLogin_Saml2_Utils.validate_sign(xml_response_msg_signed_2, cert_2))
@@ -892,7 +891,7 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         # expired cert
         self.assertTrue(OneLogin_Saml2_Utils.validate_sign(xml_response_assert_signed, cert))
         # expired cert, verified it
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(xml_response_assert_signed, cert, validatecert=True))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, xml_response_assert_signed, cert, validatecert=True)
 
         xml_response_assert_signed_2 = b64decode(self.file_contents(join(self.data_path, 'responses', 'signed_assertion_response2.xml.base64')))
         self.assertTrue(OneLogin_Saml2_Utils.validate_sign(xml_response_assert_signed_2, cert_2))
@@ -903,7 +902,7 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
         # expired cert
         self.assertTrue(OneLogin_Saml2_Utils.validate_sign(xml_response_double_signed, cert))
         # expired cert, verified it
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(xml_response_double_signed, cert, validatecert=True))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, xml_response_double_signed, cert, validatecert=True)
 
         xml_response_double_signed_2 = b64decode(self.file_contents(join(self.data_path, 'responses', 'double_signed_response2.xml.base64')))
         self.assertTrue(OneLogin_Saml2_Utils.validate_sign(xml_response_double_signed_2, cert_2))
@@ -916,33 +915,33 @@ class OneLogin_Saml2_Utils_Test(unittest.TestCase):
 
         dom.firstChild.getAttributeNode('ID').nodeValue = u'_34fg27g212d63k1f923845324475802ac0fc24530b'
         # Reference validation failed
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(dom, cert_2))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, dom, cert_2)
 
         invalid_fingerprint = 'afe71c34ef740bc87434be13a2263d31271da1f9'
         # Wrong fingerprint
-        self.assertFalse(OneLogin_Saml2_Utils.validate_metadata_sign(xml_metadata_signed_2, None, invalid_fingerprint))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_metadata_sign, xml_metadata_signed_2, None, invalid_fingerprint)
 
         dom_2 = parseString(xml_response_double_signed_2)
         self.assertTrue(OneLogin_Saml2_Utils.validate_sign(dom_2, cert_2))
         dom_2.firstChild.firstChild.firstChild.nodeValue = 'https://example.com/other-idp'
         # Modified message
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(dom_2, cert_2))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, dom_2, cert_2)
 
         # Try to validate directly the Assertion
         dom_3 = parseString(xml_response_double_signed_2)
         assert_elem_3 = dom_3.firstChild.firstChild.nextSibling.nextSibling.nextSibling
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(assert_elem_3, cert_2))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, assert_elem_3, cert_2)
 
         # Wrong scheme
         no_signed = b64decode(self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_signature.xml.base64')))
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(no_signed, cert))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, no_signed, cert)
 
         no_key = b64decode(self.file_contents(join(self.data_path, 'responses', 'invalids', 'no_key.xml.base64')))
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(no_key, cert))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, no_key, cert)
 
         # Signature Wrapping attack
         wrapping_attack1 = b64decode(self.file_contents(join(self.data_path, 'responses', 'invalids', 'signature_wrapping_attack.xml.base64')))
-        self.assertFalse(OneLogin_Saml2_Utils.validate_sign(wrapping_attack1, cert))
+        self.assertRaises(Exception, OneLogin_Saml2_Utils.validate_sign, wrapping_attack1, cert)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR changes some error messages around to carry more details, but more importantly removes some roadblocks that were suppressing already-extant detailed error messages from being available for analysis. We've also added hooks on `OneLogin_Saml2_Auth` to retrieve the most recently sent request XML body, and the most recent XML response body.

**Dependencies**: None

**Author notes and concerns**:
1. ~~I'm getting a segfault on the integration testing. That _really_ shouldn't be happening for Python, period, so that's a Bad Thing. I'm gonna look into that further, but the really odd thing is that it's segfaulting even on a particular commit for my branch that passes on the main branch.~~ Still not sure why this is happening, but I can't replicate when running the tests locally, so I have to assume it's something up with Travis.
- [ ] @bradenmacdonald for initial review
